### PR TITLE
Translate core components to English

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-# Делает объект FastAPI доступным как `from app import app`
+# Makes the FastAPI instance available via `from app import app`
 from .main import app
 
 __all__ = ["app"]

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,22 +1,22 @@
 <!doctype html>
-<html lang="ru">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Скрининг риска инфаркта</title>
+  <title>Heart Attack Risk Screening</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="icon" href="data:,">
   <link rel="stylesheet" href="{{ url_for('static', path='/style.css') }}?v={{ version }}">
 </head>
 <body>
   <main class="container">
-    <h1>Загрузите CSV для предсказания риска сердечного приступа</h1>
+    <h1>Upload a CSV to predict heart attack risk</h1>
 
     <form class="upload" action="/" method="post" enctype="multipart/form-data">
       <label class="filebox">
-        <span>📁 Выберите CSV файл</span>
+        <span>📁 Choose a CSV file</span>
         <input type="file" name="file" accept=".csv" required />
       </label>
-      <button class="primary" type="submit">🧠 Сделать прогноз</button>
+      <button class="primary" type="submit">🧠 Run prediction</button>
     </form>
 
     {% if error %}
@@ -25,16 +25,16 @@
 
     {% if summary %}
       <div class="alert ok">
-        ✅ Готово! Количество пациентов: <b>{{ summary.n_patients }}</b>
+        ✅ Done! Number of patients: <b>{{ summary.n_patients }}</b>
       </div>
 
       <div class="stats">
         <div class="stat">
-          <span class="label">⚠️ Высокий риск:</span>
+          <span class="label">⚠️ High risk:</span>
           <b>{{ summary.n_high }}</b> ({{ "%.1f"|format(summary.p_high) }}%)
         </div>
         <div class="stat">
-          <span class="label">🟢 Риска нет:</span>
+          <span class="label">🟢 No risk:</span>
           <b>{{ summary.n_low }}</b> ({{ "%.1f"|format(summary.p_low) }}%)
         </div>
         <div class="bar">
@@ -44,17 +44,17 @@
       </div>
 
       <div class="actions">
-        <a class="secondary" href="/download">⬇️ Скачать результаты (CSV)</a>
+        <a class="secondary" href="/download">⬇️ Download results (CSV)</a>
       </div>
 
       <div class="list">
         {% for row in rows %}
           <div class="item">
-            <div class="left">Пациент {{ row.idx }}</div>
+            <div class="left">Patient {{ row.idx }}</div>
             {% if row.pred == 1 %}
-              <div class="badge danger">⚠️ ВЫСОКИЙ РИСК</div>
+              <div class="badge danger">⚠️ HIGH RISK</div>
             {% else %}
-              <div class="badge safe">🟢 РИСКА НЕТ</div>
+              <div class="badge safe">🟢 NO RISK</div>
             {% endif %}
             <div class="proba">p = {{ "%.3f"|format(row.proba) }}</div>
           </div>

--- a/src/inference_utils.py
+++ b/src/inference_utils.py
@@ -1,57 +1,57 @@
-# файл: src/inference_utils.py
+# file: src/inference_utils.py
 from __future__ import annotations
 
 """
-HeartRiskInference — продакшен-обёртка для инференса риска инфаркта.
+HeartRiskInference — production wrapper for heart attack risk inference.
 
-Назначение
-----------
-Класс загружает лучшую модель и метаданные из папки `artifacts/`, приводит сырые данные
-к формату обучения (через EDAAnalyzer) и выдаёт:
-  • вероятности положительного класса (predict_proba);
-  • таблицу с вероятностью и бинарным решением (predict);
-  • готовый к сдаче (ТЗ/соревнование) DataFrame ровно из двух колонок: `id`, `prediction`
-    (predict_for_submission) — это минимальный формат, который обычно требуется.
+Purpose
+-------
+The class loads the best model and metadata from the `artifacts/` folder,
+brings raw data to the training format (via EDAAnalyzer) and provides:
+  • positive class probabilities (`predict_proba`);
+  • a table with probability and binary decision (`predict`);
+  • a ready-to-submit DataFrame with exactly two columns: `id`, `prediction`
+    (`predict_for_submission`) — the minimal format usually required.
 
-Формат артефактов (лежит в <корень_репозитория>/artifacts)
-----------------------------------------------------------
+Artifact format (stored in <repository_root>/artifacts)
+------------------------------------------------------
 - `best_meta.json`:
     {
       "model_key": "cat | rf | hgb",
-      "features": ["..."],          # список признаков (и их порядок) как при обучении
-      "cats": ["..."],              # подмножество features — категориальные при обучении
-      "threshold": 0.42,            # оптимальный порог (под F_beta) по OoF
+      "features": ["..."],          # feature list (and order) as during training
+      "cats": ["..."],              # subset of features that were categorical
+      "threshold": 0.42,            # optimal threshold (F_beta) on OoF
       "model_path": "best_model.cbm | best_model.joblib | best_model.pkl"
     }
-- файл модели:
+- model file:
     - CatBoost  -> best_model.cbm
-    - sklearn   -> best_model.joblib (или .pkl) — пайплайн с OHE внутри
+    - sklearn   -> best_model.joblib (or .pkl) — pipeline with OHE inside
 
-Где искать artifacts/
---------------------
-По умолчанию строго `<корень_проекта>/artifacts`, где корень — это папка, содержащая `src/`
-(вычисляется как parents[1] от этого файла). Можно передать альтернативный путь в
+Where to find artifacts/
+-----------------------
+By default `<project_root>/artifacts`, where project root is the folder containing `src/`
+(computed as parents[1] of this file). You can pass an alternative path to
 `HeartRiskInference.from_dir(artifacts_dir=...)`.
 
-Быстрый старт (в ноутбуке/скрипте)
-----------------------------------
+Quick start (notebook/script)
+-----------------------------
 >>> import pandas as pd
 >>> from src.inference_utils import HeartRiskInference
->>> inf = HeartRiskInference.from_dir()                # загрузит артефакты из ./artifacts
+>>> inf = HeartRiskInference.from_dir()                # load artifacts from ./artifacts
 >>> df_test = pd.read_csv("data/heart_test.csv")
 
-# 1) Аналитический сценарий: вероятности + метки
->>> preds = inf.predict(df_test)                       # колонки: proba, prediction
+# 1) Analytical scenario: probabilities + labels
+>>> preds = inf.predict(df_test)                       # columns: proba, prediction
 >>> preds.head()
 
-# 2) Готовый файл под ТЗ/соревнование: 2 колонки
+# 2) Ready-to-submit file: 2 columns
 >>> submit = inf.predict_for_submission(df_test, id_col="id")
->>> submit.to_csv("submission.csv", index=False)       # файл содержит колонки: id,prediction
+>>> submit.to_csv("submission.csv", index=False)       # file has columns: id,prediction
 
-Примечания
-----------
-• Для CatBoost передаются индексы категориальных признаков в Pool().
-• Для sklearn (RF/HGB) загружается сохранённый пайплайн (preproc + модель) через joblib.
+Notes
+-----
+• For CatBoost, categorical feature indices are passed to Pool().
+• For sklearn (RF/HGB) the saved pipeline (preproc + model) is loaded via joblib.
 """
 
 from pathlib import Path
@@ -67,17 +67,17 @@ from eda_analyzer import EDAAnalyzer
 
 class HeartRiskInference:
     """
-    Класс для инференса (получения предсказаний) по сохранённым артефактам.
+    Inference class for generating predictions from saved artifacts.
 
-    Обычно используйте фабрику `from_dir(...)` — она найдёт и загрузит модель/метаавытоматы.
+    Usually use the factory `from_dir(...)` — it will find and load the model and metadata.
 
     Args:
-        model: Загруженный обученный estimator/пайплайн (CatBoostClassifier или sklearn Pipeline).
+        model: Loaded trained estimator/pipeline (CatBoostClassifier or sklearn Pipeline).
         model_key: 'cat' | 'rf' | 'hgb'.
-        features: Список имён признаков и их порядок на инференсе (как при обучении).
-        cats_train: Имена категориальных признаков (подмножество features).
-        threshold: Оптимальный порог (из OoF), применяемый для бинаризации вероятностей.
-        artifacts_dir: Путь к папке с артефактами (для отчётности/метаданных).
+        features: List of feature names and their order for inference (as during training).
+        cats_train: Names of categorical features (subset of features).
+        threshold: Optimal threshold (from OoF) used to binarize probabilities.
+        artifacts_dir: Path to the artifacts directory (for reporting/metadata).
     """
 
     def __init__(
@@ -91,30 +91,30 @@ class HeartRiskInference:
     ):
         self.model = model
         self.model_key = str(model_key)         # 'cat' | 'rf' | 'hgb'
-        self.features = list(features)          # точный порядок признаков
-        self.cats_train = list(cats_train)      # категориальные при обучении
-        self.threshold = float(threshold)       # сохранённый порог
+        self.features = list(features)          # exact feature order
+        self.cats_train = list(cats_train)      # categorical features during training
+        self.threshold = float(threshold)       # saved threshold
         self.artifacts_dir = Path(artifacts_dir) if artifacts_dir is not None else None
 
-    # ---------- Фабрика загрузки из artifacts ----------
+    # ---------- Factory: load from artifacts ----------
 
     @classmethod
     def from_dir(cls, artifacts_dir: Optional[str | Path] = None) -> "HeartRiskInference":
         """
-        Загружает модель и метаданные из папки артефактов.
+        Load model and metadata from the artifacts folder.
 
-        По умолчанию ищет в <repo_root>/artifacts (где <repo_root> — папка, содержащая `src/`).
+        By default searches `<repo_root>/artifacts` (where `<repo_root>` is the folder containing `src/`).
 
         Args:
-            artifacts_dir: альтернативный путь к каталогу артефактов.
+            artifacts_dir: alternative path to the artifacts directory.
 
         Returns:
-            Экземпляр HeartRiskInference.
+            Instance of HeartRiskInference.
 
         Raises:
-            FileNotFoundError: если нет best_meta.json или файла модели.
-            KeyError: если в best_meta.json отсутствуют нужные поля.
-            ValueError: если model_key неизвестен.
+            FileNotFoundError: if best_meta.json or model file is missing.
+            KeyError: if required fields are absent in best_meta.json.
+            ValueError: if model_key is unknown.
         """
         # <repo_root>/src/inference_utils.py -> parents[1] == <repo_root>
         repo_root = Path(__file__).resolve().parents[1]
@@ -126,8 +126,8 @@ class HeartRiskInference:
         meta_path = artifacts_dir / "best_meta.json"
         if not meta_path.is_file():
             raise FileNotFoundError(
-                f"Не найден файл метаданных {meta_path}. "
-                f"Сначала обучите и сохраните модель (HeartRiskJob.run_and_save())."
+                f"Metadata file not found: {meta_path}. "
+                f"Train and save the model first (HeartRiskJob.run_and_save())."
             )
 
         with open(meta_path, "r", encoding="utf-8") as f:
@@ -135,17 +135,17 @@ class HeartRiskInference:
 
         for k in ("model_key", "features", "cats", "threshold", "model_path"):
             if k not in meta:
-                raise KeyError(f"В {meta_path} отсутствует ключ '{k}'")
+                raise KeyError(f"Key '{k}' is missing in {meta_path}")
 
         model_key  = str(meta["model_key"])
         features   = list(meta["features"])
         cats_train = list(meta["cats"])
         threshold  = float(meta["threshold"])
 
-        model_name = Path(meta["model_path"]).name  # в метаданных хранится ТОЛЬКО имя файла
+        model_name = Path(meta["model_path"]).name  # meta stores only the file name
         model_path = artifacts_dir / model_name
         if not model_path.is_file():
-            raise FileNotFoundError(f"Файл модели не найден: {model_path}")
+            raise FileNotFoundError(f"Model file not found: {model_path}")
 
         if model_key == "cat":
             mdl = CatBoostClassifier()
@@ -153,7 +153,7 @@ class HeartRiskInference:
         elif model_key in ("rf", "hgb"):
             mdl = joblib.load(model_path)
         else:
-            raise ValueError(f"Неизвестный model_key='{model_key}'. Ожидается: 'cat' | 'rf' | 'hgb'.")
+            raise ValueError(f"Unknown model_key='{model_key}'. Expected: 'cat' | 'rf' | 'hgb'.")
 
         return cls(
             model=mdl,
@@ -164,30 +164,30 @@ class HeartRiskInference:
             artifacts_dir=artifacts_dir,
         )
 
-    # ---------- Подготовка данных ----------
+    # ---------- Data preparation ----------
 
     @staticmethod
     def _prepare_X(df: pd.DataFrame, features: Iterable[str]) -> pd.DataFrame:
         """
-        Приводит сырые данные к формату обучения:
-          1) прогон через EDAAnalyzer,
-          2) удаление таргета, если он случайно есть,
-          3) reindex к точному списку features (лишнее отбрасывается, недостающее заполняется 0).
+        Bring raw data to training format:
+          1) run through EDAAnalyzer,
+          2) drop target column if it appears,
+          3) reindex to the exact feature list (extra dropped, missing filled with 0).
 
         Returns:
-            pd.DataFrame, готовый к подаче в модель.
+            pd.DataFrame ready for the model.
         """
         proc = EDAAnalyzer(df, target_col=None).process()
         if "Heart Attack Risk (Binary)" in proc.columns:
             proc = proc.drop(columns=["Heart Attack Risk (Binary)"])
         return proc.reindex(columns=list(features), fill_value=0)
 
-    # ---------- Инференс ----------
+    # ---------- Inference ----------
 
     def predict_proba(self, df: pd.DataFrame) -> pd.Series:
         """
-        Вероятности положительного класса (риск=1) с индексом исходного df.
-        Пустой вход -> пустая Series (name='proba').
+        Probabilities of the positive class (risk=1) with the index of input df.
+        Empty input -> empty Series (name='proba').
         """
         if df is None or len(df) == 0:
             return pd.Series(dtype=float, name="proba")
@@ -204,9 +204,9 @@ class HeartRiskInference:
 
     def predict(self, df: pd.DataFrame) -> pd.DataFrame:
         """
-        Итоговая таблица для анализа:
-          • proba — вероятность класса 1,
-          • prediction — бинарное решение по сохранённому порогу self.threshold.
+        Final table for analysis:
+          • proba — probability of class 1,
+          • prediction — binary decision using saved threshold self.threshold.
         """
         p = self.predict_proba(df)
         if p.empty:
@@ -216,31 +216,31 @@ class HeartRiskInference:
 
     def predict_for_submission(self, df: pd.DataFrame, id_col: str = "id") -> pd.DataFrame:
         """
-        Две колонки — `id`, `prediction`.
+        Two columns — `id`, `prediction`.
 
         Args:
-            df: входной DataFrame с колонкой идентификатора (по умолчанию 'id').
-            id_col: имя колонки с идентификатором пациента.
+            df: input DataFrame with identifier column (default 'id').
+            id_col: name of the patient identifier column.
 
         Returns:
-            DataFrame с колонками ["id", "prediction"] (или [id_col, "prediction"]).
+            DataFrame with columns ["id", "prediction"] (or [id_col, "prediction"]).
         """
         preds = self.predict(df)
         if preds.empty:
             return pd.DataFrame(columns=[id_col, "prediction"])
 
         if id_col not in df.columns:
-            raise KeyError(f"Во входном df нет колонки '{id_col}'")
+            raise KeyError(f"Column '{id_col}' not found in input dataframe")
 
         return pd.DataFrame({
             id_col: df[id_col].values,
             "prediction": preds["prediction"].values,
         })
 
-    # ---------- Утилиты ----------
+    # ---------- Utilities ----------
 
     def meta(self) -> Dict[str, object]:
-        """Короткая сводка метаданных без повторного чтения JSON."""
+        """Short metadata summary without reading JSON again."""
         return {
             "model_key": self.model_key,
             "n_features": len(self.features),
@@ -250,7 +250,7 @@ class HeartRiskInference:
         }
 
     def class_distribution(self, df: pd.DataFrame) -> Dict[int, int]:
-        """Распределение предсказанных классов {0: count, 1: count} по результату predict()."""
+        """Distribution of predicted classes {0: count, 1: count} from predict()."""
         preds = self.predict(df)
         if preds.empty:
             return {0: 0, 1: 0}


### PR DESCRIPTION
## Summary
- translate FastAPI entrypoint and template comments to English
- document inference utilities in English for readability

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd8fda4d4c8329b6001c18b39fe208